### PR TITLE
Add JWT refresh token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@ cd spring-rest-demo
 ```
 
 El endpoint `/api/auth/login` acepta un `email` y `password` y devuelve un token JWT que se debe incluir en la cabecera `Authorization` como `Bearer <token>` para acceder al resto de la API.
+
+Los tokens caducan tras una hora. Para obtener uno nuevo puede llamarse a `/api/auth/refresh` enviando el token actual en la cabecera `Authorization`.

--- a/spring-rest-demo/src/main/java/com/example/springrestdemo/AuthController.java
+++ b/spring-rest-demo/src/main/java/com/example/springrestdemo/AuthController.java
@@ -1,10 +1,10 @@
 package com.example.springrestdemo;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,5 +30,18 @@ public class AuthController {
         Map<String, String> response = new HashMap<>();
         response.put("token", token);
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<Map<String, String>> refresh(HttpServletRequest request) {
+        String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String token = authHeader.substring(7);
+            String newToken = jwtUtil.refreshToken(token);
+            Map<String, String> response = new HashMap<>();
+            response.put("token", newToken);
+            return ResponseEntity.ok(response);
+        }
+        return ResponseEntity.badRequest().build();
     }
 }

--- a/spring-rest-demo/src/main/java/com/example/springrestdemo/SecurityConfig.java
+++ b/spring-rest-demo/src/main/java/com/example/springrestdemo/SecurityConfig.java
@@ -22,7 +22,7 @@ public class SecurityConfig {
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                 .authorizeRequests()
-                .antMatchers("/api/auth/login").permitAll()
+                .antMatchers("/api/auth/login", "/api/auth/refresh").permitAll()
                 .anyRequest().authenticated();
         http.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();


### PR DESCRIPTION
## Summary
- implement new `/refresh` endpoint to obtain a new token
- expose expiration helper methods in `JwtUtil`
- allow refresh endpoint in security configuration
- document token expiry and refresh usage in README

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_686f9f3fe2c4832da886cfa9b9a73d61